### PR TITLE
Add worldpay-enterprise to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ A simple Java/Scala payment gateway SPI
 | [Pelecard](http://www.pelecard.com/)               | [libpay-pelecard](https://github.com/wix/libpay-pelecard)                       |
 | [Stripe](https://stripe.com/)                      | [libpay-stripe](https://github.com/wix/libpay-stripe)                           |
 | [Tranzila](http://www.tranzila.co.il/)             | [libpay-tranzila](https://github.com/wix/libpay-tranzila)                       |
-| [Worldpay](http://www.worldpay.com/)               | [libpay-worldpay](https://github.com/wix/libpay-worldpay)                       |
+| [Worldpay-SMB](http://www.worldpay.com/)           | [libpay-worldpay-smb](https://github.com/wix/libpay-worldpay-smb)               |
 | [Worldpay-Enterprise](http://www.worldpay.com/)    | [libpay-worldpay-enterprise](https://github.com/wix/libpay-worldpay-enterprise) |

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 A simple Java/Scala payment gateway SPI
 
 ## Supported payment gateways
-| Payment Gateway                                    | Project                                                               |
-| -------------------------------------------------- | --------------------------------------------------------------------- |
-| [2checkout](https://www.2checkout.com/)            | [libpay-2checkout](https://github.com/wix/libpay-2checkout)           |
-| [Authorize.Net](https://www.authorize.net/)        | [libpay-authorizenet](https://github.com/wix/libpay-authorizenet)     |
-| [Braintree](https://www.braintreepayments.com/)    | [libpay-braintree](https://github.com/wix/libpay-braintree)           |
-| [CreditGuard](http://www.creditguard.co.il/)       | [libpay-creditguard](https://github.com/wix/libpay-creditguard)       |
-| [Dengi Online](https://dengionline.com/)           | [libpay-dengionline](https://github.com/wix/libpay-dengionline)       |
-| [eWAY](https://eway.io/)                           | [libpay-eway](https://github.com/wix/libpay-eway)                     |
-| [Fat Zebra](https://www.fatzebra.com.au/)          | [libpay-fatzebra](https://github.com/wix/libpay-fatzebra)             |
-| [Leumi Card](https://www.leumi-card.co.il/)        | [libpay-leumicard](https://github.com/wix/libpay-leumicard)           |
-| [MercadoPago](https://www.mercadopago.com/)        | [libpay-mercadopago](https://github.com/wix/libpay-mercadopago)       |
-| [MercuryPay](https://www.mercurypay.com/)          | [libpay-mercurypay](https://github.com/wix/libpay-mercurypay)         |
-| [Paguelo Facil](http://www.paguelofacil.com/)      | [libpay-paguelofacil](https://github.com/wix/libpay-paguelofacil)     |
-| [Pay Box](http://www.paybox.com/)                  | [libpay-paybox](https://github.com/wix/libpay-paybox)                 |
-| [Payment Express](https://www.paymentexpress.com/) | [libpay-paymentexpress](https://github.com/wix/libpay-paymentexpress) |
-| [PayPal](https://www.paypal.com/)                  | [libpay-paypal](https://github.com/wix/libpay-paypal)                 |
-| [Pelecard](http://www.pelecard.com/)               | [libpay-pelecard](https://github.com/wix/libpay-pelecard)             |
-| [Stripe](https://stripe.com/)                      | [libpay-stripe](https://github.com/wix/libpay-stripe)                 |
-| [Tranzila](http://www.tranzila.co.il/)             | [libpay-tranzila](https://github.com/wix/libpay-tranzila)             |
-| [Worldpay](http://www.worldpay.com/)               | [libpay-worldpay](https://github.com/wix/libpay-worldpay)             |
+| Payment Gateway                                    | Project                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Authorize.Net](http://www.authorize.net/)         | [libpay-authorizenet](https://github.com/wix/libpay-authorizenet)               |
+| [Braintree](https://www.braintreepayments.com/)    | [libpay-braintree](https://github.com/wix/libpay-braintree)                     |
+| [CreditGuard](http://www.creditguard.co.il/)       | [libpay-creditguard](https://github.com/wix/libpay-creditguard)                 |
+| [Dengi Online](https://dengionline.com/)           | [libpay-dengionline](https://github.com/wix/libpay-dengionline)                 |
+| [eWAY](https://eway.io/)                           | [libpay-eway](https://github.com/wix/libpay-eway)                               |
+| [Fat Zebra](https://www.fatzebra.com.au/)          | [libpay-fatzebra](https://github.com/wix/libpay-fatzebra)                       |
+| [Leumi Card](https://www.leumi-card.co.il/)        | [libpay-leumicard](https://github.com/wix/libpay-leumicard)                     |
+| [MercadoPago](https://www.mercadopago.com/)        | [libpay-mercadopago](https://github.com/wix/libpay-mercadopago)                 |
+| [MercuryPay](https://www.mercurypay.com/)          | [libpay-mercurypay](https://github.com/wix/libpay-mercurypay)                   |
+| [Paguelo Facil](http://www.paguelofacil.com/)      | [libpay-paguelofacil](https://github.com/wix/libpay-paguelofacil)               |
+| [Pay Box](http://www.paybox.com/)                  | [libpay-paybox](https://github.com/wix/libpay-paybox)                           |
+| [Payment Express](https://www.paymentexpress.com/) | [libpay-paymentexpress](https://github.com/wix/libpay-paymentexpress)           |
+| [PayPal](https://www.paypal.com/)                  | [libpay-paypal](https://github.com/wix/libpay-paypal)                           |
+| [Pelecard](http://www.pelecard.com/)               | [libpay-pelecard](https://github.com/wix/libpay-pelecard)                       |
+| [Stripe](https://stripe.com/)                      | [libpay-stripe](https://github.com/wix/libpay-stripe)                           |
+| [Tranzila](http://www.tranzila.co.il/)             | [libpay-tranzila](https://github.com/wix/libpay-tranzila)                       |
+| [Worldpay](http://www.worldpay.com/)               | [libpay-worldpay](https://github.com/wix/libpay-worldpay)                       |
+| [Worldpay-Enterprise](http://www.worldpay.com/)    | [libpay-worldpay-enterprise](https://github.com/wix/libpay-worldpay-enterprise) |


### PR DESCRIPTION
Actually, this change renames the existing libpay-worldpay (that uses the XML-based API) to libpay-worldpay-enterprise and instead libpay-worldpay will implement the JSON-based API for SMBs.